### PR TITLE
run prerepublish script if present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const {
   getPackageVersionInfo,
   destructPackageNameWithVersion,
 } = require('./utils')
+const execa = require('execa')
 
 /**
  *
@@ -51,6 +52,11 @@ async function republishPackage(identifier, target, { publishArgs = [], registry
   console.log('Unique identifier for this publish', packageJson.uniqePublishIdentifier)
   writeFileSync(join(dirPath, 'package.json'), JSON.stringify(packageJson))
   console.log(`Wrote the target version ${targetPackageVersion} to the package.json`)
+
+  await execa('npm', ['run', 'prerepublish', '--if-present'], {
+    cwd: dirPath,
+    stdio: 'inherit'
+  })
 
   return new Promise((resolve, reject) => {
     const subProcess = exec(


### PR DESCRIPTION
To allow users to make changes to their package upon republish, I added the ability to add a `prerepublish` script to the `package.json` and we will run that script before doing the republish.

I don't feel this is the most correct solution in the world, but it unblocks projects that need it.